### PR TITLE
Add proxy

### DIFF
--- a/default.py
+++ b/default.py
@@ -40,6 +40,7 @@ youtubeUrl = "http://www.youtube.com/leanback"
 vimeoUrl = "http://www.vimeo.com/couchmode"
 fields = (('title', '', 30003, True),
           ('url', 'http://', 30004, True),
+          ('proxy', '', 30013, True),
           ('thumb', 'DefaultFolder.png', None, False),
           ('stopPlayback','no', 30009, True),
           ('kiosk', 'yes', 30016, True),
@@ -196,7 +197,7 @@ def getFileName(title):
     return (''.join(c for c in unicode(title, 'utf-8') if c not in '/\\:?"*|<>')).strip()
 
 
-def getFullPath(exePath, url, useKiosk, userAgent):
+def getFullPath(exePath, url, useKiosk, userAgent, proxy):
     args = [exePath,]
     if useOwnProfile:
         args.append('--user-data-dir=%s' % profileFolder)
@@ -205,7 +206,9 @@ def getFullPath(exePath, url, useKiosk, userAgent):
         if useOwnProfile and osLinux:
             updateOwnProfile()
     if userAgent:
-        args.append('--user-agent="%s" % userAgent')
+        args.append('--user-agent="%s"' % userAgent)
+    if proxy:
+        args.append('--proxy-server=%s' % proxy)
 
     # Flashing a white screen on switching to chrome looks bad, so I'll use a temp html file with black background
     # to redirect to our desired location.
@@ -282,7 +285,7 @@ def bringChromeToFront(pid):
         pass
 
 
-def showSite(url, stopPlayback, kiosk, userAgent):
+def showSite(url, stopPlayback, kiosk, userAgent, proxy):
     creationFlags = 0
     if osWin:
         creationFlags = 0x00000008 # DETACHED_PROCESS https://msdn.microsoft.com/en-us/library/windows/desktop/ms684863(v=vs.85).aspx
@@ -293,7 +296,7 @@ def showSite(url, stopPlayback, kiosk, userAgent):
     if osAndroid:
         openAndroidBrowser(url)
     else:
-        params = getFullPath(exePath, url, kiosk, userAgent)
+        params = getFullPath(exePath, url, kiosk, userAgent, proxy)
         s = subprocess.Popen(params, shell=False, creationflags=creationFlags, close_fds = True)
         s.communicate()
 
@@ -333,8 +336,8 @@ def parameters_string_to_dict(parameters):
     return paramDict
 
 
-def addDir(title, url, mode, thumb, stopPlayback="", kiosk=""):
-    u = sys.argv[0]+"?url="+urllib.quote_plus(url)+"&mode="+urllib.quote_plus(mode)+"&stopPlayback="+urllib.quote_plus(stopPlayback)+"&kiosk="+urllib.quote_plus(kiosk)
+def addDir(title, url, mode, thumb, stopPlayback="", kiosk="", proxy=""):
+    u = sys.argv[0]+"?url="+urllib.quote_plus(url)+"&mode="+urllib.quote_plus(mode)+"&stopPlayback="+urllib.quote_plus(stopPlayback)+"&kiosk="+urllib.quote_plus(kiosk)+"&proxy="+urllib.quote_plus(proxy)
     ok = True
     liz = xbmcgui.ListItem(title, iconImage="DefaultFolder.png", thumbnailImage=thumb)
     liz.setInfo(type="Video", infoLabels={"Title": title})
@@ -342,8 +345,8 @@ def addDir(title, url, mode, thumb, stopPlayback="", kiosk=""):
     return ok
 
 
-def addSiteDir(title, url, mode, thumb, stopPlayback, kiosk):
-    u = sys.argv[0]+"?url="+urllib.quote_plus(url)+"&mode="+urllib.quote_plus(mode)+"&stopPlayback="+urllib.quote_plus(stopPlayback)+"&kiosk="+urllib.quote_plus(kiosk)
+def addSiteDir(title, url, mode, thumb, stopPlayback, kiosk, proxy):
+    u = sys.argv[0]+"?url="+urllib.quote_plus(url)+"&mode="+urllib.quote_plus(mode)+"&stopPlayback="+urllib.quote_plus(stopPlayback)+"&kiosk="+urllib.quote_plus(kiosk)+"&proxy="+urllib.quote_plus(proxy)
     ok = True
     liz = xbmcgui.ListItem(title, iconImage="DefaultFolder.png", thumbnailImage=thumb)
     liz.setInfo(type="Video", infoLabels={"Title": title})
@@ -359,12 +362,13 @@ url = urllib.unquote_plus(params.get('url', ''))
 stopPlayback = urllib.unquote_plus(params.get('stopPlayback', 'no'))
 kiosk = urllib.unquote_plus(params.get('kiosk', 'yes'))
 userAgent = urllib.unquote_plus(params.get('userAgent', ''))
+proxy = urllib.unquote_plus(params.get('proxy', ''))
 
 
 if mode == 'addSite':
     addSite()
 elif mode == 'showSite':
-    showSite(url, stopPlayback, kiosk, userAgent)
+    showSite(url, stopPlayback, kiosk, userAgent, proxy)
 elif mode == 'removeSite':
     removeSite(url)
 elif mode == 'editSite':

--- a/default.py
+++ b/default.py
@@ -38,6 +38,10 @@ if not os.path.isdir(siteFolder):
 
 youtubeUrl = "http://www.youtube.com/leanback"
 vimeoUrl = "http://www.vimeo.com/couchmode"
+# Data fields for each site. Each is a tuple of
+# (field_name, default_value, translation_id, ask_user)
+# If ask_user is False, the user will not be queried and
+# the translation_id can be None
 fields = (('title', '', 30003, True),
           ('url', 'http://', 30004, True),
           ('proxy', '', 30013, True),
@@ -51,6 +55,7 @@ translation_ids = {f[0]: f[2] for f in fields}
 prompted_fields = tuple(f[0] for f in fields if f[3])
 
 def get_default_fields():
+    """Return a dict mapping field_name -> default value"""
     return {f[0]:f[1] for f in fields}
 
 def find_exe(pathlist):
@@ -118,6 +123,12 @@ def updateOwnProfile():
         xbmc.log("Can't update chrome resolution")
 
 def read_link_file(filename):
+    """Read site data fields from a link file
+
+    Returns a dict mapping field_name -> value.
+    Default values are provided for missing fields
+
+    """
     data = get_default_fields()
     with open(filename, 'r') as fh:
         for line in fh.readlines():
@@ -127,6 +138,7 @@ def read_link_file(filename):
     return data
 
 def write_link_file(filename, data):
+    """Write a dict of site fields to a link file"""
     content = '\n'.join('{}={}'.format(k, v) for k, v in data.items())
     with open(filename, 'w') as fh:
         fh.write(content)

--- a/default.py
+++ b/default.py
@@ -38,6 +38,19 @@ if not os.path.isdir(siteFolder):
 
 youtubeUrl = "http://www.youtube.com/leanback"
 vimeoUrl = "http://www.vimeo.com/couchmode"
+fields = (('title', '', 30003, True),
+          ('url', 'http://', 30004, True),
+          ('thumb', 'DefaultFolder.png', None, False),
+          ('stopPlayback','no', 30009, True),
+          ('kiosk', 'yes', 30016, True),
+)
+# Translation ids for data fields as in the .po files
+translation_ids = {f[0]: f[2] for f in fields}
+# The field names that the user should be prompted for
+prompted_fields = tuple(f[0] for f in fields if f[3])
+
+def get_default_fields():
+    return {f[0]:f[1] for f in fields}
 
 def find_exe(pathlist):
     for path in pathlist:
@@ -67,7 +80,7 @@ def openAndroidBrowser(url):
 
 
 def updateOwnProfile():
-    # On Linux, chrome kiosk leavs black bars on side/bottom of screen due to an incorrect working size.
+    # On Linux, chrome kiosk leaves black bars on side/bottom of screen due to an incorrect working size.
     # We can fix the preferences directly
     # cat $prefs |perl -pe "s/\"work_area_bottom.*/\"work_area_bottom\": $(xrandr | grep \* | cut -d' ' -f4 | cut -d'x' -f2),/" > $prefs
     # cat $prefs |perl -pe "s/\"work_area_right.*/\"work_area_right\": $(xrandr | grep \* | cut -d' ' -f4 | cut -d'x' -f1),/" > $prefs
@@ -103,36 +116,64 @@ def updateOwnProfile():
     except:
         xbmc.log("Can't update chrome resolution")
 
+def read_link_file(filename):
+    data = get_default_fields()
+    with open(filename, 'r') as fh:
+        for line in fh.readlines():
+            entry = line[:line.find("=")]
+            content = line[line.find("=")+1:].strip()
+            data[entry] = content
+    return data
+
+def write_link_file(filename, data):
+    content = '\n'.join('{}={}'.format(k, v) for k, v in data.items())
+    with open(filename, 'w') as fh:
+        fh.write(content)
+
 def index():
     files = os.listdir(siteFolder)
     for file in files:
         if file.endswith(".link"):
-            fh = open(os.path.join(siteFolder, file), 'r')
-            title = ""
-            url = ""
-            thumb = ""
-            kiosk = "yes"
-            stopPlayback = "no"
-            for line in fh.readlines():
-                entry = line[:line.find("=")]
-                content = line[line.find("=")+1:]
-                if entry == "title":
-                    title = content.strip()
-                elif entry == "url":
-                    url = content.strip()
-                elif entry == "thumb":
-                    thumb = content.strip()
-                elif entry == "kiosk":
-                    kiosk = content.strip()
-                elif entry == "stopPlayback":
-                    stopPlayback = content.strip()
-            fh.close()
-            addSiteDir(title, url, 'showSite', thumb, stopPlayback, kiosk)
+            data = read_link_file(os.path.join(siteFolder, file))
+            addSiteDir(mode='showSite', **data)
+
     addDir("[ Vimeo Couchmode ]", vimeoUrl, 'showSite', os.path.join(addonPath, "vimeo.png"), "yes", "yes")
     addDir("[ Youtube Leanback ]", youtubeUrl, 'showSite', os.path.join(addonPath, "youtube.png"), "yes", "yes")
     addDir("[B]- "+translation(30001)+"[/B]", "", 'addSite', "")
     xbmcplugin.endOfDirectory(pluginhandle)
 
+def prompt_user(fields, defaults):
+    """Prompt user for data fields
+
+    Parameters
+    ==========
+
+    fields : seq of str
+        Names of the field the user should be prompted for. Prompted in order.
+    defaults : dict
+        Map field name -> default value. Note, every field must have a default
+
+    Returns
+    =======
+    data : dict or None
+        Maps field name -> value provided by user. None if the user aborted.
+
+    """
+    data = {}
+    for data_key in fields:
+        keyboard = xbmc.Keyboard(defaults[data_key],
+                                 translation(translation_ids[data_key]))
+        keyboard.doModal()
+        if keyboard.isConfirmed() and keyboard.getText():
+            data[data_key] = keyboard.getText()
+        else:
+            break
+    else:
+        # Python obscura: Do this if we did not break out of the loop
+        # In other words, the user did not abort, so return the entered data
+        return data
+    # We did not hit the for-else, so the user aborted.
+    return None
 
 def addSite(site="", title=""):
     if site:
@@ -142,26 +183,12 @@ def addSite(site="", title=""):
         fh.write(content)
         fh.close()
     else:
-        keyboard = xbmc.Keyboard('', translation(30003))
-        keyboard.doModal()
-        if keyboard.isConfirmed() and keyboard.getText():
-            title = keyboard.getText()
-            keyboard = xbmc.Keyboard('http://', translation(30004))
-            keyboard.doModal()
-            if keyboard.isConfirmed() and keyboard.getText():
-                url = keyboard.getText()
-                keyboard = xbmc.Keyboard('no', translation(30009))
-                keyboard.doModal()
-                if keyboard.isConfirmed() and keyboard.getText():
-                    stopPlayback = keyboard.getText()
-                    keyboard = xbmc.Keyboard('yes', translation(30016))
-                    keyboard.doModal()
-                    if keyboard.isConfirmed() and keyboard.getText():
-                        kiosk = keyboard.getText()
-                        content = "title="+title+"\nurl="+url+"\nthumb=DefaultFolder.png\nstopPlayback="+stopPlayback+"\nkiosk="+kiosk
-                        fh = open(os.path.join(siteFolder, getFileName(title)+".link"), 'w')
-                        fh.write(content)
-                        fh.close()
+        data = get_default_fields()
+        # Prompt user for required site data
+        data_from_user = prompt_user(prompted_fields, defaults=data)
+        if data_from_user:
+            data.update(data_from_user)
+            write_link_file(os.path.join(siteFolder, getFileName(data['title'])+".link"), data)
     xbmc.executebuiltin("Container.Refresh")
 
 
@@ -283,51 +310,15 @@ def removeSite(title):
 
 def editSite(title):
     filenameOld = getFileName(title)
-    file = os.path.join(siteFolder, filenameOld+".link")
-    fh = open(file, 'r')
-    title = ""
-    url = ""
-    kiosk = "yes"
-    thumb = "DefaultFolder.png"
-    stopPlayback = "no"
-    for line in fh.readlines():
-        entry = line[:line.find("=")]
-        content = line[line.find("=")+1:]
-        if entry == "title":
-            title = content.strip()
-        elif entry == "url":
-            url = content.strip()
-        elif entry == "kiosk":
-            kiosk = content.strip()
-        elif entry == "thumb":
-            thumb = content.strip()
-        elif entry == "stopPlayback":
-            stopPlayback = content.strip()
-    fh.close()
-
+    data = read_link_file(os.path.join(siteFolder, filenameOld+".link"))
     oldTitle = title
-    keyboard = xbmc.Keyboard(title, translation(30003))
-    keyboard.doModal()
-    if keyboard.isConfirmed() and keyboard.getText():
-        title = keyboard.getText()
-        keyboard = xbmc.Keyboard(url, translation(30004))
-        keyboard.doModal()
-        if keyboard.isConfirmed() and keyboard.getText():
-            url = keyboard.getText()
-            keyboard = xbmc.Keyboard(stopPlayback, translation(30009))
-            keyboard.doModal()
-            if keyboard.isConfirmed() and keyboard.getText():
-                stopPlayback = keyboard.getText()
-                keyboard = xbmc.Keyboard(kiosk, translation(30016))
-                keyboard.doModal()
-                if keyboard.isConfirmed() and keyboard.getText():
-                    kiosk = keyboard.getText()
-                    content = "title="+title+"\nurl="+url+"\nthumb="+thumb+"\nstopPlayback="+stopPlayback+"\nkiosk="+kiosk
-                    fh = open(os.path.join(siteFolder, getFileName(title)+".link"), 'w')
-                    fh.write(content)
-                    fh.close()
-                    if title != oldTitle:
-                        os.remove(os.path.join(siteFolder, filenameOld+".link"))
+    user_data = prompt_user(prompted_fields, data)
+    if user_data:
+        data.update(user_data)
+        title = data['title']
+        write_link_file(os.path.join(siteFolder, getFileName(title)+".link"), data)
+        if title != oldTitle:
+            os.remove(os.path.join(siteFolder, filenameOld+".link"))
     xbmc.executebuiltin("Container.Refresh")
 
 
@@ -342,22 +333,22 @@ def parameters_string_to_dict(parameters):
     return paramDict
 
 
-def addDir(name, url, mode, iconimage, stopPlayback="", kiosk=""):
+def addDir(title, url, mode, thumb, stopPlayback="", kiosk=""):
     u = sys.argv[0]+"?url="+urllib.quote_plus(url)+"&mode="+urllib.quote_plus(mode)+"&stopPlayback="+urllib.quote_plus(stopPlayback)+"&kiosk="+urllib.quote_plus(kiosk)
     ok = True
-    liz = xbmcgui.ListItem(name, iconImage="DefaultFolder.png", thumbnailImage=iconimage)
-    liz.setInfo(type="Video", infoLabels={"Title": name})
+    liz = xbmcgui.ListItem(title, iconImage="DefaultFolder.png", thumbnailImage=thumb)
+    liz.setInfo(type="Video", infoLabels={"Title": title})
     ok = xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url=u, listitem=liz, isFolder=True)
     return ok
 
 
-def addSiteDir(name, url, mode, iconimage, stopPlayback, kiosk):
+def addSiteDir(title, url, mode, thumb, stopPlayback, kiosk):
     u = sys.argv[0]+"?url="+urllib.quote_plus(url)+"&mode="+urllib.quote_plus(mode)+"&stopPlayback="+urllib.quote_plus(stopPlayback)+"&kiosk="+urllib.quote_plus(kiosk)
     ok = True
-    liz = xbmcgui.ListItem(name, iconImage="DefaultFolder.png", thumbnailImage=iconimage)
-    liz.setInfo(type="Video", infoLabels={"Title": name})
+    liz = xbmcgui.ListItem(title, iconImage="DefaultFolder.png", thumbnailImage=thumb)
+    liz.setInfo(type="Video", infoLabels={"Title": title})
 
-    liz.addContextMenuItems([(translation(30006), 'RunPlugin(plugin://'+addonID+'/?mode=editSite&url='+urllib.quote_plus(name)+')',), (translation(30002), 'RunPlugin(plugin://'+addonID+'/?mode=removeSite&url='+urllib.quote_plus(name)+')',)])
+    liz.addContextMenuItems([(translation(30006), 'RunPlugin(plugin://'+addonID+'/?mode=editSite&url='+urllib.quote_plus(title)+')',), (translation(30002), 'RunPlugin(plugin://'+addonID+'/?mode=removeSite&url='+urllib.quote_plus(title)+')',)])
     ok = xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url=u, listitem=liz, isFolder=True)
     return ok
 

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -58,6 +58,10 @@ msgctxt "#30012"
 msgid "Use own user profile (Could take some time on first start)"
 msgstr ""
 
+msgctxt "#30013"
+msgid "Proxy"
+msgstr "Http Proxy, empty for system default"
+
 msgctxt "#30016"
 msgid "Use kiosk mode?"
 msgstr ""


### PR DESCRIPTION
Adds ability to specify a http proxy per site. Useful if you need to direct traffic through different network paths per site.

I am making this PR since the @rasjani repo seems to be the most up to date, cleanest and actually working version of this extension, but there are some caveats to my changes:

1) Perhaps not everyone wants to configure a proxy. Leaving it empty will use the OS default setting, so not too much extra work. One could argue that the Kodi settings should be queried for the default, but I did not have time to look into that.
2) I don't think this will work on Android since the proxy setting is passed using the `--proxy-server` command line parameter while the Android one seems to do an OS library call.
3) I haven't done any translations, I just added the prompt string to the `English/strings.po` file. The prompt text did not actually show up on my Kodi, perhaps I need to reinstall the plugin to make this work (I just edited the plugin in-place). Otherwise, I'd be quite pleased to learn what I did wrong ;)
4) I just cannot stand repeating myself, and the keyboard prompting code's levels of indentation was getting crazy, so I made the process of adding, editing, saving and retrieving the per-site settings a bit more data driven. I think this is better, but everyone will not necessarily agree :)

Merge if you like, feel free to make suggestions if you feel changes are needed.